### PR TITLE
Renames database

### DIFF
--- a/cms1b/settings/dev.py
+++ b/cms1b/settings/dev.py
@@ -23,7 +23,7 @@ except ImportError:
 DATABASES = {
     'default': {
         'ENGINE': 'zappa_django_utils.db.backends.s3sqlite',
-        'NAME': 'sqlite.db',
+        'NAME': 'rebuild.db',
         'BUCKET': 'wagtail-dev'
     }
 }


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This changes the name of the database, in order to trigger a fresh deploy. This will involve the purging of all database content, but c'est la vie.

#### Helpful background context (if appropriate)
It turns out that abandoning a PR, without explicitly un-doing all db migrations, can screw things up.

After pushing this change, we needed to follow the instructions here under "Deploy the site using Zappa"
https://gist.github.com/nealtodd/45e230bcfe809d76596a4af3540112d5#deploy-the-site-using-zappa
